### PR TITLE
build(ios): widen podspec source_files glob

### DIFF
--- a/RNShareMenu.podspec
+++ b/RNShareMenu.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.swift_version = "5.2"
 
 
-  s.source_files = "ios/**/*.{h,m,mm,swift}"
+  s.source_files = "ios/**/*.{h,m,mm,swift,cpp}"
   s.exclude_files = [
     "ios/ShareViewController.swift",
     "ios/ReactShareViewController.swift",


### PR DESCRIPTION
Include .cpp in the source_files alternation so future C++ files under ios/ are picked up by CocoaPods without needing another podspec change:

  ios/**/*.{h,m,mm,swift} → ios/**/*.{h,m,mm,swift,cpp}

Purely additive — no .cpp files exist in ios/ today, so the compiled output is unchanged.